### PR TITLE
Continue indentation in multiline dictionary, array or tuple

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -1,5 +1,5 @@
 import {parser} from "lezer-python"
-import {continuedIndent, indentNodeProp, foldNodeProp, foldInside, LezerLanguage, LanguageSupport} from "@codemirror/language"
+import {continuedIndent, delimitedIndent, indentNodeProp, foldNodeProp, foldInside, LezerLanguage, LanguageSupport} from "@codemirror/language"
 import {styleTags, tags as t} from "@codemirror/highlight"
 
 /// A language provider based on the [Lezer Python
@@ -10,9 +10,9 @@ export const pythonLanguage = LezerLanguage.define({
     props: [
       indentNodeProp.add({
         Body: continuedIndent({except: /^\s*(else|elif|except|finally)\b/}),
-        TupleExpression: continuedIndent(),
-        DictionaryExpression: continuedIndent(),
-        ArrayExpression: continuedIndent(),
+        TupleExpression: delimitedIndent(),
+        DictionaryExpression: delimitedIndent(),
+        ArrayExpression: delimitedIndent(),
         Script: context => {
           if (context.pos + /\s*/.exec(context.textAfter)![0].length < context.node.to)
             return context.continue()

--- a/src/python.ts
+++ b/src/python.ts
@@ -10,6 +10,8 @@ export const pythonLanguage = LezerLanguage.define({
     props: [
       indentNodeProp.add({
         Body: continuedIndent({except: /^\s*(else|elif|except|finally)\b/}),
+        DictionaryExpression: continuedIndent(),
+        ArrayExpression: continuedIndent(),
         Script: context => {
           if (context.pos + /\s*/.exec(context.textAfter)![0].length < context.node.to)
             return context.continue()

--- a/src/python.ts
+++ b/src/python.ts
@@ -10,6 +10,7 @@ export const pythonLanguage = LezerLanguage.define({
     props: [
       indentNodeProp.add({
         Body: continuedIndent({except: /^\s*(else|elif|except|finally)\b/}),
+        TupleExpression: continuedIndent(),
         DictionaryExpression: continuedIndent(),
         ArrayExpression: continuedIndent(),
         Script: context => {


### PR DESCRIPTION
Following the update in [this commit](https://github.com/codemirror/lang-python/commit/11078ad3fc08fac5eda676e363226eef2d65d0bb) and [this discussion](https://github.com/codemirror/codemirror.next/issues/538); here is a suggested PR to continue indentation in dictionary, array or tuple blocks.

Currently when you hit return to create an array, dictionary or tuple block the cursor maintains the base indentation:

```python
a = {
| # <- cursor here after return
}

b = [
| # <- cursor here after return
]

c = (
| # <- cursor here after return
)
```

This PR adds `TupleExpression: continuedIndent()`, `DictionaryExpression: continuedIndent()` and `ArrayExpression: continuedIndent()` to `indentNodeProp` which gives the following experience:

```python
a = {
  | # <- cursor here after return
}

b = [
  | # <- cursor here after return
]

c = (
  | # <- cursor here after return
)
```
