### PR TITLE
Revise Python indent behaviour

### DIFF
--- a/test/test-indent.ts
+++ b/test/test-indent.ts
@@ -1,0 +1,109 @@
+import { python } from "@codemirror/lang-python";
+import { getIndentation, IndentContext } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import ist from "ist";
+
+const cursor = "█";
+
+function check(code: string, expected: number | null) {
+  return () => {
+    let naiveInBrackets = Boolean(code.match(/[{\[(]█[}\])]/))
+    code = /^\n*([^]*)/.exec(code)![1]
+    let pos = code.indexOf(cursor)
+    code = code.replace(cursor, "")
+    let state = EditorState.create({doc: code, extensions: [python().language]})
+    let cx = new IndentContext(state, {simulateBreak: pos, simulateDoubleBreak: naiveInBrackets})
+    ist(expected, getIndentation(cx, pos))
+  }
+}
+
+describe("python indentation", () => {
+  it("indents body", check(`
+if True:█
+`, 2))
+  it("continues body indents", check(`
+if True:
+  a = 1█
+`, 2))
+it("is happy with manual dedent blank", check(`
+if True:
+  a = 1
+█
+`, 0))
+it("is happy with manual dedent blank 2", check(`
+if True:
+  a = 1
+
+█
+`, 0))
+  it("is happy with manual dedent non-blank", check(`
+if True:
+  a = 1
+b = 2█
+`, 0))
+  it("follows manual indent", check(`
+if True:
+  a = 1
+    b = 2█
+`, 4))
+  it("dedents after pass", check(`
+if True:
+  pass█
+`, 0))
+  it("dedents after raise", check(`
+if True:
+  raise ValueError()█
+`, 0))
+  it("dedents after break", check(`
+while True:
+  break█
+`, 0))
+  it("dedents after continue", check(`
+while True:
+  continue█
+`, 0))
+  it("dedents after return", check(`
+def foo():
+  return 1█
+`, 0))
+  it("does not dedent mid-raise", check(`
+def foo():
+  raise ValueError(█)
+`, 4))
+  it("does not dedent mid-return", check(`
+def foo():
+  return foo(█1)
+`, 4))
+  it("respects indent of previous line", check(`
+if True:
+    a = 2█
+`, 4))
+  it("indents list", check(`
+a = [█]
+`, 2))
+  it("indents tuple", check(`
+a = (█)
+`, 2))
+  it("indents dictionary", check(`
+a = {█}
+`, 2))
+  it("indents parameter list", check(`
+def foo(█)
+`, 2))
+  it("indents argument list", check(`
+foo(█)
+`, 2))
+  it("no inappropriate dedent for else", check(`
+if True:
+  if True:
+    a = 1
+  else:█
+`, 4))
+  it("no dedent for else at all", check(`
+if True:
+  if True:
+    a = 1
+    else:█
+`, 4)) // Could add this if we could exclude the case above.
+       // Attempting it was controversial in VS code and it was reverted.
+})


### PR DESCRIPTION
I've been testing the Python authoring experience and comparing to VS Code. I think the VS Code indentation generally feels more usual for Python. There are a few cases where CM feels like it is getting in the way and fighting a user's indentation changes and a few where it's not helpful in what feel to me to be clear-cut scenarios.

I've attempted to align the behaviour as I explored this. Details and exceptions noted below. Just a draft PR for now for discussion. Happy to move discussion wherever you'd prefer.

I think it captures the behaviours that I'm interested in. I'm not so confident in the implementation yet. I'll test it some more over the coming days but would love some feedback. Hopefully the tests provide some cases to try out that illustrate differences. I appreciate that indentation preferences can be subjective but I'm interested in exploring whether these changes make sense for lang-python.

Demos:
- [Revised indent behaviour sandbox](https://codesandbox.io/s/revised-indent-behaviour-61jb8?file=/src/python.ts)
- [Current indent behaviour for easy comparison](https://codesandbox.io/s/current-indent-behaviour-sj04j?file=/src/index.js)

I've focussed on the automatic indent when typing code and I'm hazy on other uses of indent within CodeMirror. Will my approach here cause issues with other indent-related features?

CC @mattpauldavies based on recent interest in Python indentation.

----

Details of the change:

This aims to follow VS Code's behaviour and biases towards not changing
the indent as the user may be in the middle of rearranging code.

As an exception, we implement dedent behaviour for return and raise.
VS Code doesn't do this as they don't have a way to tell if you're in
the middle of the expression after the return or raise.

Significant changes:

- Adds dedent behaviour for constructs that must end a body.
- Adds delimited indents for argument lists, parameter lists and
  parathesized expressions. The latter is necessary for tuple indents to
  work properly as a tuple isn't parsed as such when first being written.
- Doesn't fight manual dedents. Previously trying to dedent then leave a
  blank line or two before the next statement would result in a reindent.
- Removes dedent for else and similar to match VS Code. VS Code has
  attempted to add these in the past but has had to revert because of
  users finding them more annoying than helpful. The implementation here
  was double-dedenting if the user dedented manually and wrote a valid
  if/else statement.